### PR TITLE
Update GitHub Actions workflow to allow publishing with uncommitted changes

### DIFF
--- a/.github/workflows/wangamail-rs.yml
+++ b/.github/workflows/wangamail-rs.yml
@@ -319,7 +319,7 @@ jobs:
         working-directory: wangamail-rs
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --token "$CARGO_REGISTRY_TOKEN"
+        run: cargo publish --allow-dirty
 
       - name: Job summary
         if: always()


### PR DESCRIPTION
- Modified the cargo publish command to include the --allow-dirty flag, enabling the publishing of packages with uncommitted changes in the working directory.