### PR TITLE
fix(workflows): update GITHUB_OUTPUT handling in Python scripts

### DIFF
--- a/.github/workflows/wangamail-rs.yml
+++ b/.github/workflows/wangamail-rs.yml
@@ -189,6 +189,7 @@ jobs:
         working-directory: wangamail-rs
         run: |
           python3 - <<'PY'
+          import os
           import re
           from pathlib import Path
 
@@ -208,8 +209,11 @@ jobs:
                 break
           if not version:
             raise SystemExit("Error: Failed to extract [package].version from Cargo.toml")
-          out = Path("${GITHUB_OUTPUT}")
-          out.write_text(out.read_text(encoding="utf-8") + f"version={version}\n", encoding="utf-8")
+          out_path = os.environ.get("GITHUB_OUTPUT")
+          if not out_path:
+            raise SystemExit("Error: GITHUB_OUTPUT is not set")
+          with open(out_path, "a", encoding="utf-8") as f:
+            f.write(f"version={version}\n")
           print(f"Current version: {version}")
           PY
 

--- a/.github/workflows/wangapayfast-rs.yml
+++ b/.github/workflows/wangapayfast-rs.yml
@@ -189,6 +189,7 @@ jobs:
         working-directory: wangapayfast-rs
         run: |
           python3 - <<'PY'
+          import os
           import re
           from pathlib import Path
 
@@ -208,8 +209,11 @@ jobs:
                 break
           if not version:
             raise SystemExit("Error: Failed to extract [package].version from Cargo.toml")
-          out = Path("${GITHUB_OUTPUT}")
-          out.write_text(out.read_text(encoding="utf-8") + f"version={version}\n", encoding="utf-8")
+          out_path = os.environ.get("GITHUB_OUTPUT")
+          if not out_path:
+            raise SystemExit("Error: GITHUB_OUTPUT is not set")
+          with open(out_path, "a", encoding="utf-8") as f:
+            f.write(f"version={version}\n")
           print(f"Current version: {version}")
           PY
 


### PR DESCRIPTION
- Added import of `os` module for environment variable access.
- Changed output handling to retrieve `GITHUB_OUTPUT` from environment variables and write the version to the specified path, improving error handling for unset variables.