### PR TITLE
chore(workflows): improve version extraction in GitHub workflows

### DIFF
--- a/.github/workflows/wangamail-rs.yml
+++ b/.github/workflows/wangamail-rs.yml
@@ -348,7 +348,20 @@ jobs:
         id: version
         working-directory: wangamail-rs
         run: |
-          V=$(grep '^version = ' Cargo.toml | sed -n 's/.*"\([^"]*\)".*/\1/p')
+          V=$(awk '
+            $0 == "[package]" { in_pkg = 1; next }
+            in_pkg && /^\[/ { in_pkg = 0 }
+            in_pkg && /^version[[:space:]]*=/ {
+              if (match($0, /"[^"]+"/)) {
+                print substr($0, RSTART + 1, RLENGTH - 2)
+                exit
+              }
+            }
+          ' Cargo.toml)
+          if [ -z "$V" ]; then
+            echo "Error: Failed to extract package version from Cargo.toml"
+            exit 1
+          fi
           echo "version=$V" >> $GITHUB_OUTPUT
           echo "Version: $V"
 

--- a/.github/workflows/wangapayfast-rs.yml
+++ b/.github/workflows/wangapayfast-rs.yml
@@ -348,7 +348,20 @@ jobs:
         id: version
         working-directory: wangapayfast-rs
         run: |
-          V=$(grep '^version = ' Cargo.toml | sed -n 's/.*"\([^"]*\)".*/\1/p')
+          V=$(awk '
+            $0 == "[package]" { in_pkg = 1; next }
+            in_pkg && /^\[/ { in_pkg = 0 }
+            in_pkg && /^version[[:space:]]*=/ {
+              if (match($0, /"[^"]+"/)) {
+                print substr($0, RSTART + 1, RLENGTH - 2)
+                exit
+              }
+            }
+          ' Cargo.toml)
+          if [ -z "$V" ]; then
+            echo "Error: Failed to extract package version from Cargo.toml"
+            exit 1
+          fi
           echo "version=$V" >> $GITHUB_OUTPUT
           echo "Version: $V"
 


### PR DESCRIPTION
- Replaced `grep` and `sed` with `awk` for more robust version extraction from `Cargo.toml`.
- Added error handling to notify if the version extraction fails, enhancing workflow reliability.