### PR TITLE
fix(workflows): implement retry logic for git push in CI workflows

### DIFF
--- a/.github/workflows/wangamail-csharp.yml
+++ b/.github/workflows/wangamail-csharp.yml
@@ -155,7 +155,15 @@ jobs:
             git commit -m "chore(wangamail-csharp): bump version to ${{ steps.bump.outputs.new_version }} [skip ci]"
             git fetch origin main || true
             git pull origin main --rebase || git pull origin main --no-rebase || true
-            git push origin main || git push origin main --force-with-lease
+            # Retry push to avoid stale-ref/lock failures when remote updates
+            for _ in 1 2 3; do
+              if git push origin main; then
+                break
+              fi
+              git fetch origin main || true
+              git pull origin main --rebase || git pull origin main --no-rebase || true
+              git push origin main --force-with-lease || true
+            done
           fi
 
       - name: Job summary

--- a/.github/workflows/wangamail-rs.yml
+++ b/.github/workflows/wangamail-rs.yml
@@ -279,7 +279,15 @@ jobs:
             # Sync with remote main to avoid non-fast-forward push failures
             git fetch origin main || true
             git pull origin main --rebase || git pull origin main --no-rebase || true
-            git push origin main || git push origin main --force-with-lease
+            # Retry push to avoid stale-ref/lock failures when remote updates
+            for _ in 1 2 3; do
+              if git push origin main; then
+                break
+              fi
+              git fetch origin main || true
+              git pull origin main --rebase || git pull origin main --no-rebase || true
+              git push origin main --force-with-lease || true
+            done
           fi
 
       - name: Job summary

--- a/.github/workflows/wangapayfast-csharp.yml
+++ b/.github/workflows/wangapayfast-csharp.yml
@@ -148,7 +148,15 @@ jobs:
             git commit -m "chore(wangapayfast-csharp): bump version to ${{ steps.bump.outputs.new_version }} [skip ci]"
             git fetch origin main || true
             git pull origin main --rebase || git pull origin main --no-rebase || true
-            git push origin main || git push origin main --force-with-lease
+            # Retry push to avoid stale-ref/lock failures when remote updates
+            for _ in 1 2 3; do
+              if git push origin main; then
+                break
+              fi
+              git fetch origin main || true
+              git pull origin main --rebase || git pull origin main --no-rebase || true
+              git push origin main --force-with-lease || true
+            done
           fi
 
       - name: Job summary

--- a/.github/workflows/wangapayfast-rs.yml
+++ b/.github/workflows/wangapayfast-rs.yml
@@ -341,7 +341,15 @@ jobs:
             # Sync with remote main to avoid non-fast-forward push failures
             git fetch origin main || true
             git pull origin main --rebase || git pull origin main --no-rebase || true
-            git push origin main || git push origin main --force-with-lease
+            # Retry push to avoid stale-ref/lock failures when remote updates
+            for _ in 1 2 3; do
+              if git push origin main; then
+                break
+              fi
+              git fetch origin main || true
+              git pull origin main --rebase || git pull origin main --no-rebase || true
+              git push origin main --force-with-lease || true
+            done
           fi
 
       - name: Job summary


### PR DESCRIPTION
- Updated the git push commands in `wangamail-csharp.yml`, `wangamail-rs.yml`, `wangapayfast-csharp.yml`, and `wangapayfast-rs.yml` to include a retry mechanism. This change aims to handle stale-ref and lock failures more gracefully by attempting multiple pushes after fetching and pulling from the remote main branch.