### PR TITLE
chore(workflows): update CI conditions and remove redundant build step

### DIFF
--- a/.github/workflows/wangamail-csharp.yml
+++ b/.github/workflows/wangamail-csharp.yml
@@ -40,7 +40,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     needs: format
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET
@@ -63,7 +63,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET
@@ -172,40 +172,10 @@ jobs:
           echo "## Bump Version" >> $GITHUB_STEP_SUMMARY
           echo "**New version:** ${{ steps.bump.outputs.new_version }}" >> $GITHUB_STEP_SUMMARY
 
-  build-release:
-    name: Build
-    runs-on: ubuntu-latest
-    needs: version-bump
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Pull latest (version bump)
-        run: git pull origin main || true
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '8.0.x'
-
-      - name: Restore
-        run: dotnet restore wangamail-csharp/WangaMail.CSharp.csproj
-
-      - name: Build release
-        run: dotnet build wangamail-csharp/WangaMail.CSharp.csproj -c Release --no-restore
-
-      - name: Job summary
-        if: always()
-        run: |
-          echo "## Build" >> $GITHUB_STEP_SUMMARY
-          echo "**Status:** ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
-
   get-version:
     name: Get Version
     runs-on: ubuntu-latest
-    needs: [version-bump, build-release]
+    needs: [version-bump]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -326,7 +296,7 @@ jobs:
     name: Monitor Failed Jobs
     runs-on: ubuntu-latest
     if: always() && failure()
-    needs: [format, build, test, version-bump, build-release, get-version, publish, release]
+    needs: [format, build, test, version-bump, get-version, publish, release]
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
- Modified the conditions for the build and test jobs in `wangamail-csharp.yml` to trigger on both pull requests and pushes.
- Removed the `build-release` job as it was redundant, streamlining the workflow dependencies for the `get-version` job.